### PR TITLE
improved check for main file

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -44,7 +44,7 @@ Package.prototype = {
                 path.join(this.path, 'component.json')
             ],
             data = paths.reduce(function(prev, curr) {
-                if (prev !== null) {
+                if (prev !== null && typeof prev.main !== 'undefined') {
                     return prev;
                 }
 


### PR DESCRIPTION
_comment on the source code says - Collects data from first found config file_
This fix the problem when in first file there is no **main** field at all.

example of problem bower modules:
- backbone-amd
- underscore-amd
