### PR TITLE
Log objects and arrays correctly

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,8 @@ module.exports = function() {
 	var args = Array.prototype.slice.call(arguments);
 
 	args = args.map(function(arg, i) {
-		return arg[colors[i]];
+		var val = typeof arg === 'object' ? JSON.stringify(arg) : arg;
+		return val[colors[i]];
 	});
 
 	console.log.apply(console.log, args);


### PR DESCRIPTION
As it is now only `undefined` show up in the console when debugging, e.g:

```
Package      overriding dependencies     angular-route undefined
```

With this PR we'll get:

```
Package      overriding dependencies     angular-route {"angular":"1.3.4"}
```
