### PR TITLE
Replaced native existsSync with path-exists module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var fs                 = require('fs'),
+    exists             = require('path-exists').sync,
     path               = require('path'),
     globule            = require('globule'),
     PackageCollection  = require('./package_collection');
@@ -44,7 +45,7 @@ module.exports = function(filter, opts, cb) {
 
     bowerrc = path.resolve(cwd, bowerrc || '.bowerrc');
 
-    if (fs.existsSync(bowerrc) && (config = JSON.parse(fs.readFileSync(bowerrc)))) {
+    if (exists(bowerrc) && (config = JSON.parse(fs.readFileSync(bowerrc)))) {
         cwd = path.dirname(bowerrc);
         if (config.cwd) {
             cwd = path.resolve(cwd, config.cwd);
@@ -61,7 +62,7 @@ module.exports = function(filter, opts, cb) {
         path.resolve(process.cwd(), opts.paths.bowerDirectory) :
         path.resolve(cwd, bowerDirectory || 'bower_components');
 
-    if (!bowerJson || !fs.existsSync(bowerJson)) {
+    if (!bowerJson || !exists(bowerJson)) {
         error = Error('bower.json file does not exist at ' + bowerJson);
         if (cb) {
             cb(error, []);
@@ -71,7 +72,7 @@ module.exports = function(filter, opts, cb) {
         }
     }
 
-    if (!bowerDirectory || !fs.existsSync(bowerDirectory)) {
+    if (!bowerDirectory || !exists(bowerDirectory)) {
         error = Error('Bower components directory does not exist at ' + bowerDirectory);
         if (cb) {
             cb(error, []);

--- a/lib/package.js
+++ b/lib/package.js
@@ -1,5 +1,6 @@
 var path    = require('path'),
     fs      = require('fs'),
+    exists  = require('path-exists').sync,
     glob    = require('glob'),
     logger  = require('./logger'),
     Package;
@@ -48,7 +49,7 @@ Package.prototype = {
                     return prev;
                 }
 
-                if (!fs.existsSync(curr)) {
+                if (!exists(curr)) {
                     return prev;
                 }
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "glob": "^4.0.3",
     "globule": "^0.2.0",
     "minimatch": "^1.0.0",
+    "path-exists": "^1.0.0",
     "strip-json-comments": "^1.0.2",
     "vinyl-fs": "^1.0.0"
   },


### PR DESCRIPTION
Because fs.exists() is being deprecated.