### PR TITLE
Enable dot option of multimatch(minimatch)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ module.exports = function(filter, opts, cb) {
         files = collection.getFiles();
 
         if (typeof opts.filter === 'string' || Array.isArray(opts.filter)) {
-            files = multimatch(files, opts.filter);
+            files = multimatch(files, opts.filter, {dot: true});
         } else if (opts.filter instanceof RegExp) {
             files = files.filter(function(file) {
                 return opts.filter.test(file);


### PR DESCRIPTION
## if working directory
* /var/foo/.bar/baz.scss

## before
```
mainBowerFiles({
      filter:'**/*.scss'
})
```

## after (this PR)
```
mainBowerFiles({
      filter:'**/*.scss'
})
```

### result
* match
