### PR TITLE
add dependency group option

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,33 @@ Type: `object` Default: `{}`
 
 Set default overrides option which can be overridden in the `overrides` section of the `bower.json`
 
+### group
+
+Type: `String` Default: `null`
+
+You can specify a group of dependencies you want to read from bower.json
+
+For example:
+
+```json
+{
+    "dependencies": {
+        "BOWER-PACKAGE-1": "*",
+        "BOWER-PACKAGE-2": "*",
+        "BOWER-PACKAGE-3": "*",
+        "BOWER-PACKAGE-4": "*"
+    },
+    "group": {
+        "home": [ "BOWER-PACKAGE-1" ],
+        "admin": [ "BOWER-PACKAGE-1", "BOWER-PACKAGE-2", "BOWER-PACKAGE-3" ]
+    }
+}
+```
+
+```javascript
+mainBowerFiles({ paths: 'path/for/project', group: 'home' });
+```
+
 ## LICENSE
 
 (MIT License)
@@ -286,4 +313,3 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -68,6 +68,7 @@ PackageCollection.prototype = {
         }
 
         var name,
+            group = this.opts.group || null,
             includeDev = this.opts.includeDev || false,
             includeSelf = this.opts.includeSelf || false,
             bowerJson = JSON.parse(stripJsonComments(readFile(this.opts.paths.bowerJson, 'utf8'))),
@@ -79,20 +80,27 @@ PackageCollection.prototype = {
 
         this.overrides = extend(bowerJson.overrides || {}, this.overrides);
 
-        if (includeDev !== 'exclusive') {
-            for (name in dependencies) {
+        // add packages from group option or add packages entirely from bower file
+        if (group && bowerJson.group && bowerJson.group[group] && bowerJson.group[group] instanceof Array) {
+            for (name of bowerJson.group[group]) {
                 this.add(name, path.join(this.opts.paths.bowerDirectory, path.sep, name));
             }
-        }
-
-        if (includeDev !== false) {
-            for (name in devDependencies) {
-                this.add(name, path.join(this.opts.paths.bowerDirectory, path.sep, name));
+        } else {
+            if (includeDev !== 'exclusive') {
+                for (name in dependencies) {
+                    this.add(name, path.join(this.opts.paths.bowerDirectory, path.sep, name));
+                }
             }
-        }
 
-        if (includeSelf !== false) {
-            this.add(main, path.join(path.dirname(this.opts.paths.bowerJson)));
+            if (includeDev !== false) {
+                for (name in devDependencies) {
+                    this.add(name, path.join(this.opts.paths.bowerDirectory, path.sep, name));
+                }
+            }
+
+            if (includeSelf !== false) {
+                this.add(main, path.join(path.dirname(this.opts.paths.bowerJson)));
+            }
         }
     },
 

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -86,7 +86,7 @@ PackageCollection.prototype = {
                 throw new Error('group "' + group + '" does not exists in bower.json');
             }
 
-            var deps = bowerJson.group[group]
+            var deps = bowerJson.group[group];
 
             if (deps instanceof Array) {
                 for (var i in deps) {

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -81,10 +81,17 @@ PackageCollection.prototype = {
         this.overrides = extend(bowerJson.overrides || {}, this.overrides);
 
         // add packages from group option or add packages entirely from bower file
-        if (group && bowerJson.group && bowerJson.group[group] && bowerJson.group[group] instanceof Array) {
-            for (var i in bowerJson.group[group]) {
-                var name = bowerJson.group[group][i]
-                this.add(name, path.join(this.opts.paths.bowerDirectory, path.sep, name));
+        if (group && bowerJson.group) {
+            if (!bowerJson.group[group]) {
+                throw new Error('group "' + group + '" does not exists in bower.json');
+            }
+
+            var deps = bowerJson.group[group]
+
+            if (deps instanceof Array) {
+                for (var i in deps) {
+                    this.add(deps[i], path.join(this.opts.paths.bowerDirectory, path.sep, deps[i]));
+                }
             }
         } else {
             if (includeDev !== 'exclusive') {

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -82,7 +82,8 @@ PackageCollection.prototype = {
 
         // add packages from group option or add packages entirely from bower file
         if (group && bowerJson.group && bowerJson.group[group] && bowerJson.group[group] instanceof Array) {
-            for (name of bowerJson.group[group]) {
+            for (var i in bowerJson.group[group]) {
+                var name = bowerJson.group[group][i]
                 this.add(name, path.join(this.opts.paths.bowerDirectory, path.sep, name));
             }
         } else {

--- a/test/_bower_with_group.json
+++ b/test/_bower_with_group.json
@@ -9,6 +9,7 @@
         "decoy": "*"
     },
     "group": {
-        "group1": [ "simple", "multi" ]
+        "group1": [ "simple", "multi" ],
+        "containDepsError": [ "simple", "nonExistingModule" ]
     }
 }

--- a/test/_bower_with_group.json
+++ b/test/_bower_with_group.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": {
+        "simple": "*",
+        "overwritten": "*",
+        "multi": "*",
+        "ignore": "*",
+        "hasPackageNoBower": "*",
+        "deepPaths":"*",
+        "decoy": "*"
+    },
+    "group": {
+        "group1": [ "simple", "multi" ]
+    }
+}

--- a/test/main.js
+++ b/test/main.js
@@ -3,6 +3,8 @@ var mainBowerFiles = require('../'),
 
 require('should');
 
+var assert = should;
+
 describe('main-bower-files', function() {
     function expect(filenames) {
         var expectedFiles = [].concat(filenames).map(function(filename) {
@@ -301,7 +303,7 @@ describe('main-bower-files', function() {
             '/fixtures/decoy/decoy.js'
         ]).fromConfig('/_bower_with_group.json').when(done);
     });
-    
+
     it('should select the expected files from group propery in bower.json', function(done) {
         expect([
             '/fixtures/simple/simple.js',
@@ -310,4 +312,15 @@ describe('main-bower-files', function() {
         ]).fromConfig('/_bower_with_group.json', { group: 'group1' }).when(done);
     });
 
+    it('should throw an exception if group name does not exist', function() {
+        var when = expect([]).fromConfig('/_bower_with_group.json', { group: 'nonExistingGroup' }).when;
+
+        when.should.throw('group "nonExistingGroup" does not exists in bower.json');
+    });
+
+    it('should ignore nonexisting packages in the group', function(done) {
+        expect([
+            '/fixtures/simple/simple.js'
+        ]).fromConfig('/_bower_with_group.json', { group: 'containDepsError' }).when(done);
+    });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -289,4 +289,25 @@ describe('main-bower-files', function() {
             '/fixtures/overwritten/another.js'
         ]).fromConfig('/_bower_with_comments.json').when(done);
     });
+
+    it('should select all files if no group options pass to function', function(done) {
+        expect([
+            '/fixtures/simple/simple.js',
+            '/fixtures/overwritten/overwritten.js',
+            '/fixtures/multi/multi.js',
+            '/fixtures/multi/multi.css',
+            '/fixtures/hasPackageNoBower/hasPackageNoBower.js',
+            '/fixtures/deepPaths/lib/deeppaths.js',
+            '/fixtures/decoy/decoy.js'
+        ]).fromConfig('/_bower_with_group.json').when(done);
+    });
+    
+    it('should select the expected files from group propery in bower.json', function(done) {
+        expect([
+            '/fixtures/simple/simple.js',
+            '/fixtures/multi/multi.js',
+            '/fixtures/multi/multi.css'
+        ]).fromConfig('/_bower_with_group.json', { group: 'group1' }).when(done);
+    });
+
 });

--- a/test/main.js
+++ b/test/main.js
@@ -3,8 +3,6 @@ var mainBowerFiles = require('../'),
 
 require('should');
 
-var assert = should;
-
 describe('main-bower-files', function() {
     function expect(filenames) {
         var expectedFiles = [].concat(filenames).map(function(filename) {


### PR DESCRIPTION
It would be great if we can define a group which contains only some packages from `dependencies` in `bower.json` file

Consider this bower.json file.

```json
{
  "dependencies": {
    "jquery": "~2.1.4",
    "angular": "1.4",
    "angular-ui-router": "~0.2.15",
    "restangular": "~1.5.1"
  },
  "group": {
    "home": [ "jquery" ],
    "admin": [ "jquery", "angular", "angular-ui-router" ]
  }
}
```

Notice the `group` section. In some cases just `jquery` is enough for the `home` page , and we may need more (or all of them) for other pages. Instead of creating separated bower.json file for each pages, defining a group section in bower.json would be easier to manage dependencies for the project (and the bower.json file itself)

Then we specify a group as an option for `mainBowerFile` like this.

```javascript
var mainBowerFiles = require('main-bower-files');

var files = mainBowerFiles({ paths: './' });
var homeFiles = mainBowerFiles({ paths: './', group: 'home' });

console.log(files);
// [ '/home/user/project/bower_components/jquery/dist/jquery.js',
//   '/home/user/project/bower_components/angular/angular.js',
//   '/home/user/project/bower_components/angular-ui-router/release/angular-ui-router.js',
//  ' /home/user/project/bower_components/lodash/lodash.js',
//   '/home/user/project/bower_components/restangular/dist/restangular.js' ]

console.log(homeFiles);
// [ '/home/user/project/bower_components/jquery/dist/jquery.js' ]

```

Hope this help,
Porawit Poboonma