### PR TITLE
Include all dependencies except in specified group

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,12 @@ For example:
 mainBowerFiles({ paths: 'path/for/project', group: 'home' });
 ```
 
+You can include all packages except for those listed in a group with the `!` operator.
+
+```javascript
+mainBowerFiles({ paths: 'path/for/project', group: '!home' });
+```
+
 ## LICENSE
 
 (MIT License)

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -72,17 +72,16 @@ PackageCollection.prototype = {
             includeDev = this.opts.includeDev || false,
             includeSelf = this.opts.includeSelf || false,
             bowerJson = JSON.parse(stripJsonComments(readFile(this.opts.paths.bowerJson, 'utf8'))),
-            isExludingGroup = (group && bowerJson.group && group.charAt(0) === "!" && bowerJson.group[group.slice(1)] > 0),
-            devDependencies = (isExludingGroup ? this.filterByGroup(bowerJson.devDependencies) : bowerJson.devDependencies) || {},
-            dependencies = (isExludingGroup ? this.filterByGroup(bowerJson.dependencies) : bowerJson.dependencies) || {},
+            isExludingGroup = (group && bowerJson.group && group.charAt(0) === "!" && bowerJson.group[group.slice(1)].length > 0),
+            devDependencies = (isExludingGroup ? this.filterByGroup(bowerJson.devDependencies, bowerJson.group[group.slice(1)]) : bowerJson.devDependencies) || {},
+            dependencies = (isExludingGroup ? this.filterByGroup(bowerJson.dependencies, bowerJson.group[group.slice(1)]) : bowerJson.dependencies) || {},
             main = bowerJson.main || {};
 
         includeDev = includeDev === true ? 'inclusive' : includeDev;
 
         this.overrides = extend(bowerJson.overrides || {}, this.overrides);
-
         // add packages from group option, add all except in group, or add packages entirely from bower file
-        if (group && bowerJson.group && !isExclusion) {
+        if (group && bowerJson.group && !isExludingGroup) {
             if (!bowerJson.group[group]) {
                 throw new Error('group "' + group + '" does not exists in bower.json');
             }
@@ -116,6 +115,7 @@ PackageCollection.prototype = {
     filterByGroup: function (deps, group) {
         var filtered = {};
         for (var dep in deps) {
+            console.log(dep);
             if (group.indexOf(dep) === -1) {
                 filtered[dep] = deps[dep];
             }

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -115,7 +115,6 @@ PackageCollection.prototype = {
     filterByGroup: function (deps, group) {
         var filtered = {};
         for (var dep in deps) {
-            console.log(dep);
             if (group.indexOf(dep) === -1) {
                 filtered[dep] = deps[dep];
             }

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -71,17 +71,18 @@ PackageCollection.prototype = {
             group = this.opts.group || null,
             includeDev = this.opts.includeDev || false,
             includeSelf = this.opts.includeSelf || false,
+            isExludingGroup = (group && bowerJson.group && group.charAt(0) === "!" && bowerJson.group[group.slice(1)] > 0),
             bowerJson = JSON.parse(stripJsonComments(readFile(this.opts.paths.bowerJson, 'utf8'))),
-            devDependencies = bowerJson.devDependencies || {},
-            dependencies = bowerJson.dependencies || {},
+            devDependencies = (isExludingGroup ? this.filterByGroup(bowerJson.devDependencies) : bowerJson.devDependencies) || {},
+            dependencies = (isExludingGroup ? this.filterByGroup(bowerJson.dependencies) : bowerJson.dependencies) || {},
             main = bowerJson.main || {};
 
         includeDev = includeDev === true ? 'inclusive' : includeDev;
 
         this.overrides = extend(bowerJson.overrides || {}, this.overrides);
 
-        // add packages from group option or add packages entirely from bower file
-        if (group && bowerJson.group) {
+        // add packages from group option, add all except in group, or add packages entirely from bower file
+        if (group && bowerJson.group && !isExclusion) {
             if (!bowerJson.group[group]) {
                 throw new Error('group "' + group + '" does not exists in bower.json');
             }
@@ -110,6 +111,16 @@ PackageCollection.prototype = {
                 this.add(main, path.join(path.dirname(this.opts.paths.bowerJson)));
             }
         }
+    },
+
+    filterByGroup: function (deps, group) {
+        var filtered = {};
+        for (var dep in deps) {
+            if (group.indexOf(dep) === -1) {
+                filtered[dep] = deps[dep];
+            }
+        }
+        return filtered;
     },
 
     /**

--- a/lib/package_collection.js
+++ b/lib/package_collection.js
@@ -71,8 +71,8 @@ PackageCollection.prototype = {
             group = this.opts.group || null,
             includeDev = this.opts.includeDev || false,
             includeSelf = this.opts.includeSelf || false,
-            isExludingGroup = (group && bowerJson.group && group.charAt(0) === "!" && bowerJson.group[group.slice(1)] > 0),
             bowerJson = JSON.parse(stripJsonComments(readFile(this.opts.paths.bowerJson, 'utf8'))),
+            isExludingGroup = (group && bowerJson.group && group.charAt(0) === "!" && bowerJson.group[group.slice(1)] > 0),
             devDependencies = (isExludingGroup ? this.filterByGroup(bowerJson.devDependencies) : bowerJson.devDependencies) || {},
             dependencies = (isExludingGroup ? this.filterByGroup(bowerJson.dependencies) : bowerJson.dependencies) || {},
             main = bowerJson.main || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-bower-files",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "Get main files from your installed bower packages.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main-bower-files",
-  "version": "2.11.3",
+  "version": "2.12.0",
   "description": "Get main files from your installed bower packages.",
   "main": "index.js",
   "scripts": {

--- a/test/main.js
+++ b/test/main.js
@@ -302,12 +302,21 @@ describe('main-bower-files', function() {
         ]).fromConfig('/_bower_with_group.json').when(done);
     });
 
-    it('should select the expected files from group propery in bower.json', function(done) {
+    it('should select the expected files from group property in bower.json', function(done) {
         expect([
             '/fixtures/simple/simple.js',
             '/fixtures/multi/multi.js',
             '/fixtures/multi/multi.css'
         ]).fromConfig('/_bower_with_group.json', { group: 'group1' }).when(done);
+    });
+
+    it('should select all files except those listed in the group property in bower.json', function(done) {
+        expect([
+            '/fixtures/overwritten/overwritten.js',
+            '/fixtures/hasPackageNoBower/hasPackageNoBower.js',
+            '/fixtures/deepPaths/lib/deeppaths.js',
+            '/fixtures/decoy/decoy.js'
+        ]).fromConfig('/_bower_with_group.json', { group: '!group1' }).when(done);
     });
 
     it('should throw an exception if group name does not exist', function() {


### PR DESCRIPTION
Allows you to use the `!` operator to include all dependencies except those in group.
```
{"group": "!groupname"}
```
fixes #138 