### PR TITLE
Fix low severity vuln based on braces version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - 8.12.0

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "multimatch": "^2.0.0",
     "path-exists": "^1.0.0",
     "strip-json-comments": "^1.0.2",
-    "vinyl-fs": "^2.4.3"
+    "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
-    "mocha": "^2.0.1",
+    "grunt": "^1.0.4",
+    "grunt-cli": "^1.3.2",
+    "mocha": "^6.2.0",
     "should": "^7.0.1"
   }
 }


### PR DESCRIPTION
Dependency chain: `main-bower-files > vinyl-fs > glob-stream > micromatch > braces`

After I got started and went back to check if there was a reason not to update I noticed https://github.com/ck86/main-bower-files/pull/172

Comment: I was willing to go ahead and update the node version in `.travis.yml` because my project is unfortunately still dependent on bower for the time being (and I'd like the clear the security warnings). Based on my one day of experience in the 2016 ecosystem, node 8.x seems to hit that sweet spot of "not yet entirely EOL" and "old enough not to break all the libraries". Hoping for that green status checkmark

I recognize that you're not actively maintaining this, still cautiously optimistic and grateful for your response 🙏 